### PR TITLE
feat: release as GA

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,10 +1,10 @@
 {
   "name": "cloudtrace",
-  "name_pretty": "Stackdriver Trace",
+  "name_pretty": "Cloud Trace",
   "product_documentation": "https://cloud.google.com/trace/docs",
   "client_documentation": "https://googleapis.dev/python/cloudtrace/latest",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/559776",
-  "release_level": "alpha",
+  "release_level": "ga",
   "language": "python",
   "repo": "googleapis/python-trace",
   "distribution_name": "google-cloud-trace",

--- a/README.rst
+++ b/README.rst
@@ -1,22 +1,22 @@
-Python Client for Stackdriver Trace API
+Python Client for Cloud Trace API
 =======================================
 
-|alpha| |pypi| |versions| 
+|ga| |pypi| |versions| 
 
-The `Stackdriver Trace API`_ sends application trace data to Stackdriver Trace
+The `Cloud Trace API`_ sends application trace data to Cloud Trace
 for viewing. Trace data is collected for all App Engine applications by
 default. Trace data from other applications can be provided using this API.
 
 - `Client Library Documentation`_
 - `Product Documentation`_
 
-.. |alpha| image:: https://img.shields.io/badge/support-alpha-orange.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#alpha-support
+.. |ga| image:: https://img.shields.io/badge/support-ga-gold.svg
+   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-trace.svg
    :target: https://pypi.org/project/google-cloud-trace/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-trace.svg
    :target: https://pypi.org/project/google-cloud-trace/
-.. _Stackdriver Trace API: https://cloud.google.com/trace
+.. _Cloud Trace API: https://cloud.google.com/trace
 .. _Client Library Documentation: https://googleapis.dev/python/cloudtrace/latest
 .. _Product Documentation:  https://cloud.google.com/trace
 
@@ -54,8 +54,8 @@ Supported Python Versions
 Python >= 3.6
 
 
-Deprecated Python Versions
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+Unsupported Python Versions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Python == 2.7.
 
 The last version of this library compatible with Python 2.7 is google-cloud-trace==0.24.0
@@ -92,7 +92,7 @@ to `Python Development Environment Setup Guide`_ for Google Cloud Platform.
 Next Steps
 ~~~~~~~~~~
 
--  Read the `Client Library Documentation`_ for Stackdriver Trace API
+-  Read the `Client Library Documentation`_ for Cloud Trace API
    to see other available methods on the client.
 -  Read the `Product documentation`_ to learn more about the product and see
    How-to Guides.

--- a/setup.py
+++ b/setup.py
@@ -21,13 +21,13 @@ import setuptools
 # Package metadata.
 
 name = "google-cloud-trace"
-description = "Stackdriver Trace API client library"
+description = "Cloud Trace API client library"
 version = "1.0.0"
 # Should be one of:
 # 'Development Status :: 3 - Alpha'
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
-release_status = "Development Status :: 3 - Alpha"
+release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     "google-api-core[grpc] >= 1.22.0, < 2.0.0dev",
     "proto-plus >= 1.4.0",


### PR DESCRIPTION
Also removes mentions of "Stackdriver" to match https://cloud.google.com/trace/docs/reference


---
Package name: google-cloud-trace
Current release: **alpha**
Proposed release: **GA**

## Instructions

Check the lists below, adding tests / documentation as required. Once all the "required" boxes are ticked, please create a release and close this issue.

## Required

- [x] 28 days elapsed since last beta release with new API surface (last release September 14 https://github.com/googleapis/python-trace/releases/tag/v1.0.0)
- [x] Server API is GA ([v1 and v2](https://github.com/googleapis/python-trace/tree/master/google/cloud))
- [x] Package API is stable, and we can commit to backward compatibility
- [x] All dependencies are GA

## Optional

- [ ] Most common / important scenarios have descriptive samples
- [ ] Public manual methods have at least one usage sample each (excluding overloads)
- [ ] Per-API README includes a full description of the API
- [ ] Per-API README contains at least one “getting started” sample using the most common API scenario
- [ ] Manual code has been reviewed by API producer
- [ ] Manual code has been reviewed by a DPE responsible for samples
- [ ] 'Client Libraries' page is added to the product documentation in 'APIs & Reference' section of the product's documentation on Cloud Site
