### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,14 +1,16 @@
 {
-  "name": "cloudtrace",
-  "name_pretty": "Cloud Trace",
-  "product_documentation": "https://cloud.google.com/trace/docs",
-  "client_documentation": "https://googleapis.dev/python/cloudtrace/latest",
-  "issue_tracker": "https://issuetracker.google.com/savedsearches/559776",
-  "release_level": "ga",
-  "language": "python",
-  "library_type": "GAPIC_AUTO",
-  "repo": "googleapis/python-trace",
-  "distribution_name": "google-cloud-trace",
-  "api_id": "cloudtrace.googleapis.com",
-  "requires_billing": false
+    "name": "cloudtrace",
+    "name_pretty": "Cloud Trace",
+    "product_documentation": "https://cloud.google.com/trace/docs",
+    "client_documentation": "https://googleapis.dev/python/cloudtrace/latest",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559776",
+    "release_level": "ga",
+    "language": "python",
+    "library_type": "GAPIC_AUTO",
+    "repo": "googleapis/python-trace",
+    "distribution_name": "google-cloud-trace",
+    "api_id": "cloudtrace.googleapis.com",
+    "requires_billing": false,
+    "default_version": "",
+    "codeowner_team": ""
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -11,6 +11,6 @@
     "distribution_name": "google-cloud-trace",
     "api_id": "cloudtrace.googleapis.com",
     "requires_billing": false,
-    "default_version": "",
+    "default_version": "v2",
     "codeowner_team": ""
 }


### PR DESCRIPTION
By default the code owner will be googleapis/yoshi-python. This change is needed for the following synthtool PRs.

googleapis/synthtool#1201
googleapis/synthtool#1114