### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "cloudtrace",
     "name_pretty": "Cloud Trace",
     "product_documentation": "https://cloud.google.com/trace/docs",
-    "client_documentation": "https://googleapis.dev/python/cloudtrace/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/cloudtrace/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559776",
     "release_level": "ga",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.