### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "cloudtrace",
     "name_pretty": "Cloud Trace",
     "product_documentation": "https://cloud.google.com/trace/docs",
-    "client_documentation": "https://googleapis.dev/python/cloudtrace/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/cloudtrace/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559776",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ from applications and displays it in near real-time in the Google Cloud Console.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-trace.svg
    :target: https://pypi.org/project/google-cloud-trace/
 .. _Google Cloud Trace: https://cloud.google.com/trace
-.. _Client Library Documentation: https://googleapis.dev/python/cloudtrace/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/cloudtrace/latest
 .. _Product Documentation:  https://cloud.google.com/trace/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.